### PR TITLE
Update chrome-webstore-upload-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - '12'
 if: branch = master OR tag IS present
 before_install:
-  - npm i -g chrome-webstore-upload-cli@1.2.1 web-ext-submit@6.1.0
+  - npm i -g chrome-webstore-upload-cli@2.1.0 web-ext-submit@6.1.0
 deploy:
   provider: script
   script: npm run release

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "tsc --watch --preserveWatchOutput",
     "build": "sh build.sh",
     "release": "npm run build && npm run release:chrome && npm run release:firefox",
-    "release:chrome": "webstore upload --source=BoostPic_Chrome.zip --auto-publish",
+    "release:chrome": "chrome-webstore-upload upload --source=BoostPic_Chrome.zip --auto-publish",
     "release:firefox": "web-ext-submit --source-dir BoostPic_Chrome",
     "lint": "tsc --noEmit --skipLibCheck",
     "test": "echo \"Error: no test specified\" && exit 0"
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Leslie-Wong-H/BoostPic#readme",
   "devDependencies": {
     "@types/chrome": "0.0.157",
-    "chrome-webstore-upload-cli": "^1.2.1",
+    "chrome-webstore-upload-cli": "^2.1.0",
     "husky": "^4.3.8",
     "typescript": "^4.4.2",
     "web-ext-submit": "^6.1.0"


### PR DESCRIPTION
Main reason: to adjust to the new Google OAuth practice. 

Related Issue: https://github.com/fregante/chrome-webstore-upload/issues/59